### PR TITLE
Multi-region Usage

### DIFF
--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -107,14 +107,14 @@ data "aws_iam_policy_document" "main_scan" {
 }
 
 resource "aws_iam_role" "main_scan" {
-  name                 = "lambda-${var.name_scan}"
+  name                 = "lambda-${var.name_scan}-${var.instance}"
   assume_role_policy   = data.aws_iam_policy_document.assume_role_scan.json
   permissions_boundary = var.permissions_boundary
   tags                 = var.tags
 }
 
 resource "aws_iam_role_policy" "main_scan" {
-  name = "lambda-${var.name_scan}"
+  name = "lambda-${var.name_scan}-${var.instance}"
   role = aws_iam_role.main_scan.id
 
   policy = data.aws_iam_policy_document.main_scan.json

--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -68,14 +68,14 @@ data "aws_iam_policy_document" "main_update" {
 }
 
 resource "aws_iam_role" "main_update" {
-  name                 = "lambda-${var.name_update}"
+  name                 = "lambda-${var.name_update}-${var.instance}"
   assume_role_policy   = data.aws_iam_policy_document.assume_role_update.json
   permissions_boundary = var.permissions_boundary
   tags                 = var.tags
 }
 
 resource "aws_iam_role_policy" "main_update" {
-  name = "lambda-${var.name_update}"
+  name = "lambda-${var.name_update}-${var.instance}"
   role = aws_iam_role.main_update.id
 
   policy = data.aws_iam_policy_document.main_update.json

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,7 @@
+variable "instance" {
+  type = string
+}
+
 variable "name_scan" {
   default     = "s3-anti-virus-scan"
   description = "Name for resources associated with anti-virus scanning"


### PR DESCRIPTION
Adds an instance variable to use with string interpolation when naming resources to allow this module to be used in different regions within the same AWS account.